### PR TITLE
fix correct php version

### DIFF
--- a/Consumer/ConsumerService.php
+++ b/Consumer/ConsumerService.php
@@ -113,7 +113,7 @@ class ConsumerService
     /**
      * @param int|bool $toProcess
      */
-    private function runSynchronousConsumer($toProcess): void
+    private function runSynchronousConsumer($toProcess)
     {
         $processed = 0;
         while ($processed<$toProcess || $toProcess === true) {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "SNS"
   ],
   "require": {
-    "php": ">=7.1",
+    "php": ">=7.0",
     "aws/aws-sdk-php-symfony": "^2.0.0",
     "symfony/symfony": "2.8.*"
   },

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "SNS"
   ],
   "require": {
-    "php": ">=7.0",
+    "php": ">=7.1",
     "aws/aws-sdk-php-symfony": "^2.0.0",
     "symfony/symfony": "2.8.*"
   },


### PR DESCRIPTION
As in https://github.com/beyerz/AwsQueueBundle/blob/master/Consumer/ConsumerService.php#L116 return types are used the correct minimal php version must be `7.1` not `7.0`